### PR TITLE
Add comments_count substitution string on custom linkbacks

### DIFF
--- a/admin/jpsettings.class.php
+++ b/admin/jpsettings.class.php
@@ -55,6 +55,8 @@ class jpsettings {
          '  <dd class="description">The blog\'s permalink for your post.</dd>'.
          '  <dt class="description"><kbd>[comments_link]</kbd></dt>'.
          '  <dd class="description">The URL for comments. Generally this is the permalink URL with #comments on the end.</dd>'.
+         '  <dt class="description"><kbd>[comments_count]</kbd></dt>'.
+         '  <dd class="description">A count of the number of comments on original post.</dd>'.
          '</dl> ';
   }
   

--- a/lib/jpposts.class.php
+++ b/lib/jpposts.class.php
@@ -277,7 +277,13 @@ class jpposts {
     
     return $the_event;
   }
-  
+
+  // Return an image tag linking to a count of the comments on the Wordpress post.
+  private function comment_count_image($post_id) {
+      $link = plugins_url( "wp-lj-comments.php?post_id=".$post_id , __FILE__ );
+      return '<img src="'.$link.'" border="0">';
+  }
+ 
   // format the post header/footer
   private function getlinkback(){
     // insert the name of the page we're linking back to based on the options set
@@ -287,13 +293,15 @@ class jpposts {
         '[blog_name]',
         '[blog_link]',
         '[permalink]',
-        '[comments_link]'
+	'[comments_link]',
+	'[comments_count]'
       );
     $replace = array(
         $blogName,
         get_option('home'),
         get_permalink($this->post->ID),
-        get_permalink($this->post->ID).'#comments'
+	get_permalink($this->post->ID).'#comments',
+	$this->comment_count_image($this->post->ID)
       );
       
     return str_replace($find, $replace, $this->options['custom_header']);

--- a/lib/jpposts.class.php
+++ b/lib/jpposts.class.php
@@ -188,7 +188,6 @@ class jpposts {
     $jmeta = array(
       // userpic!
       'picture_keyword' => $this->getuserpic($jID),
-      'opt_backdated'   => $this->isbackdated($jID),
     );
     return $jmeta;
   }
@@ -382,15 +381,6 @@ class jpposts {
   // TODO: integration with WP-Flock if i ever rewrite it...
   private function getmask(){
     return 0;
-  }
-  
-  // another placeholder, since the bulk export functionality is gone
-  private function isbackdated($jID){
-    // if( $o['jp_bulk'] === true )
-    if(!$this->isnew($jID))
-      { return 1; }
-    else
-      { return 0; }
   }
   
   private function getuserpic($jID){

--- a/lib/wp-lj-comments.php
+++ b/lib/wp-lj-comments.php
@@ -1,0 +1,23 @@
+<?php
+require_once('../../../../wp-load.php');
+global $wpdb;
+$id = $_GET['post_id']; 
+$number=$wpdb->get_var("SELECT COUNT(*) FROM $wpdb->comments WHERE comment_post_ID = '$id' AND comment_approved = '1'");
+$font = 2;
+if($number < 10) $image_width = 8;
+else if ($number > 10 && $number < 100) $image_width = 16;
+else $image_width = 24; 
+$image_height = 12;
+
+/* Displaying image with comments number */
+
+header("Content-type: image/png");
+$img = @ImageCreate ($image_width, $image_height);
+$black = ImageColorAllocate($img, 0, 0, 0);
+$white = ImageColorAllocate($img, 255, 255, 255);
+$transparent = ImageColorAllocateAlpha($img, 255, 255, 255, 127);
+ImageFill($img, 0, 0, $transparent); // Background
+ImageString($img , $font, 1, 1, "$number", $black); // Font
+ImagePng($img);
+ImageDestroy($img);
+?>


### PR DESCRIPTION
Hi there, this is a copy of the lp-xp functionality which allows the post on the
journal site to get a count of the comments on the Wordpress site, by
linking to an image served by the Wordpress site, thought it'd be nice to add it to journalpress as it's the only working plugin for crossposting from Wordpress to Dreamwidth.